### PR TITLE
add facilitation guide for residency lightning talks

### DIFF
--- a/facilitation/09-residency-lightning-talks/README.md
+++ b/facilitation/09-residency-lightning-talks/README.md
@@ -1,0 +1,29 @@
+# Residency Lightning Talks
+
+> Short (time boxed) sessions interjected throughout the Enablement session to showcase and share stories of existing Labs residencies.
+
+_____
+
+
+## Slides
+
+There are no set slides or material to present and no specific expecations on presentation of content.
+
+
+## Facilitation Materials Needed
+
+* Big Visible Clock
+
+
+## Facilitation Guidelines
+
+* Around 2 weeks before the Enablement session, identify who in the room has been involved in a Labs residency prior to this session (at a minimum, some of the facilitation team should have been).
+* Ask if they are interetsed in using 7 minutes to showcase their residency.
+* There are no set expecations on presentation - it could be a 7 minute talk, a few slides, a set of photos, a demo of an app / apps, etc. etc.
+* During the Enablement session, include each Residency Lightning Talk on the Enablement Backlog.
+* We suggest injecting these talks in at various points throughout the 4 day session. Recommended times include:
+    * Just before lunch
+    * Just before a coffee break
+    * When the group need a break away from a lengthy exercise
+    * When the content of the Lightning Talk is particularly pertinent to the exerxise or other content being discussed in the wider session
+* Time box the talk with a Big Visible Clock

--- a/facilitation/09-residency-lightning-talks/README.md
+++ b/facilitation/09-residency-lightning-talks/README.md
@@ -18,12 +18,12 @@ There are no set slides or material to present and no specific expecations on pr
 ## Facilitation Guidelines
 
 * Around 2 weeks before the Enablement session, identify who in the room has been involved in a Labs residency prior to this session (at a minimum, some of the facilitation team should have been).
-* Ask if they are interetsed in using 7 minutes to showcase their residency.
-* There are no set expecations on presentation - it could be a 7 minute talk, a few slides, a set of photos, a demo of an app / apps, etc. etc.
+* Ask if they are interested in using 7 minutes to showcase their residency.
+* There are no set expectations on presentation - it could be a 7 minute talk, a few slides, a set of photos, a demo of an app / apps, etc. etc.
 * During the Enablement session, include each Residency Lightning Talk on the Enablement Backlog.
 * We suggest injecting these talks in at various points throughout the 4 day session. Recommended times include:
     * Just before lunch
     * Just before a coffee break
     * When the group need a break away from a lengthy exercise
-    * When the content of the Lightning Talk is particularly pertinent to the exerxise or other content being discussed in the wider session
+    * When the content of the Lightning Talk is particularly pertinent to the exercise or other content being discussed in the wider session
 * Time box the talk with a Big Visible Clock


### PR DESCRIPTION
added short facilitation guide for including residency lightning talks during a 4 day enablement