### PR TITLE
Add SSH setup link

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -318,6 +318,8 @@ git commit -m "Adding git and nexus config"
 git push -u origin --all
 ```
 
+If you get a "permission denied" error when running `git push -u origin --all`, try [setting an SSH key in GitLab](https://docs.gitlab.com/ee/ssh/) and then run the command again.
+
 ### Part 4 MongoDB for CI tests
 > In order to run our API tests in CI in later labs; we need there to be a MongoDB available for executing our tests. As this is part of our CI/CD Lifecycle; we will add it now.
 


### PR DESCRIPTION
I ran into a "permission denied" error when trying to do a `git push`. My Git_Hub_ credentials are stored, but my GitHub password isn't the same as my GitLab password, so authentication fails. Adding the SSH key solves this problems. Folks who are signed into other Git providers (or who just don't want to type their password each time) may benefit from this tip as well.