### PR TITLE
Update directory name

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -79,7 +79,7 @@ git clone https://github.com/rht-labs/enablement-ci-cd && cd enablement-ci-cd
 ./git-pull-all.sh
 ```
 
-3. Open the `innovation-labs` folder in VSCode (or your favourite editor). The project is laid out as follows
+3. Open the `enablement-ci-cd` folder in VSCode (or your favourite editor). The project is laid out as follows
 ```
 .
 ├── README.md


### PR DESCRIPTION
The instructions have you check out the exercises to `~/innovation-labs/enablement-ci-cd`, but they instruct you to open "Open the innovation-labs folder". It's probably clearer to have the reader open `enablement-ci-cd` so that they see the directory layout shown in the docs.

Resolves #250.