### PR TITLE
Remove 'blue balls' reference, fixes #254

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -416,7 +416,6 @@ jenkins-s2i
 greenballs:1.15
 ```
 ![green-balls.png](../images/exercise1/green-balls.png)
-Why does Jenkins have Blue Balls? More can be found [on reddit](https://www.reddit.com/r/programming/comments/4lu6q8/why_does_jenkins_have_blue_balls/) or the [jenkins blog](https://jenkins.io/blog/2012/03/13/why-does-jenkins-have-blue-balls/)
 
 5. Before building and deploying the Jenkins s2i; add git credentials to it. These will be used by Jenkins to access the Git Repositories where our apps will be stored. We want Jenkins to be able to push tags to it so write access is required. There are a few ways we can do this; either adding them to the `template/jenkins.yml` as environment Variables and then including them in the `params/jenkins` file.  We could also create a token in GitLab and use it as the source secret in the Jenkins template.
 But for simplicity just replace the `<USERNAME>` && `<PASSWORD>` in the `jenkins-s2i/configuration/init.groovy` with your LDAP credentials as seen below. This init file gets run when Jenkins launches and will setup the credentials for use in our Jobs in the next exercises


### PR DESCRIPTION
Removes the offending line containing the "blue balls" reference. This should make the conversations around this section more comfortable and not put anyone "on the spot" to explain how innuendo got into a professional deck.