### PR TITLE
Updated exercise 'inventory' to use v2.0.0 'action'

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -143,13 +143,13 @@ NAMESPACE_DISPLAY_NAME=<YOUR-NAME> Test
 ```yaml
     - name: "{{ dev_namespace }}"
       template: "{{ playbook_dir }}/templates/project-requests.yml"
-      template_action: create
+      action: create
       params: "{{ playbook_dir }}/params/project-requests-dev"
       tags:
       - projects
     - name: "{{ test_namespace }}"
       template: "{{ playbook_dir }}/templates/project-requests.yml"
-      template_action: create
+      action: create
       params: "{{ playbook_dir }}/params/project-requests-test"
       tags:
       - projects


### PR DESCRIPTION
Related to PR https://github.com/rht-labs/enablement-ci-cd/pull/14 ... to move to `openshift-applier` newest release `v2.0.0`. 

@springdo not sure if I caught everywhere where this change needs to be made, so please let me know if there anywhere else (in other branches) that needs to be updated as well. 