### PR TITLE
Update Fedora docs to use Fedora packages where possible

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -21,7 +21,7 @@ The following are the minimal hardware requirements for running the lab exercise
 * 80GB hard disk
 
 The lab exercises have been tested on the following operating systems
- * Fedora 29 64-bit
+ * Fedora 29 or 30 64-bit x86_64
  * Microsoft Windows 10 Pro 64-bit
  * macOS 10.14 "Mojave"
 
@@ -50,40 +50,34 @@ The following table lists the software requirements for running the lab exercise
 
 ### Linux
 
-1. Download the Node.js 8.x LTS Linux 64-bit binary archive file from https://nodejs.org/dist/latest-v8.x/. The binary will be named as ***node-v8.x.y-linux-x64.tar.gz***, where 'x' and 'y' indicates the major and minor version of the latest Node.js 8 LTS release.
+1. Enable the nodejs 8 modules in Fedora and install the latest nodejs 8.x LTS release.
 ```bash
-tar -xvzf node-v8.x.y-linux-x64.tar.gz -C /usr/local/
-```
-Replace 'x' and 'y' with the version you downloaded in the above step.
-
-2. Edit your ***.bashrc*** file and add the ***node*** binary to your ***PATH*** environment variable
-```bash
-echo 'export PATH=/usr/local/node-v8.x.y/bin:$PATH' >> $HOME/.bashrc
+dnf module enable nodejs:8
+dnf module install -y nodejs:8
 ```
 
-3. Install OpenJDK version 1.8
+2. Install OpenJDK version 1.8.
 ```bash
 dnf install java-1.8.0-openjdk-devel
 ```
 
-4. Install Google Chrome version 70 or higher by downloading and running the the 64-bit RPM installer from https://google.com/chrome
+3. Install Chromium version 70 or higher.
 ```bash
-dnf install google-chrome-stable_current_x86_64.rpm
+dnf install chromium
 ```
-5. Install Docker, Git and Ansible
+
+4. Install Docker, Git and Ansible.
 ```bash
 dnf install git ansible docker
 systemctl enable docker
 systemctl start docker
 ```
-6. Download and uncompress the OpenShift 3.11 client binary archive. Copy the ***oc*** binary to ***/usr/local/bin*** folder on your system
+5. Install the OpenShift 3.11 client binary.
 ```bash
-wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
-tar -xvzf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
-cp openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/local/bin/
-chmod +x /usr/local/bin/oc
+dnf install origin-clients
 ```
-7. Download and install Atom text editor RPM installer from https://atom.io/download/rpm, or the Visual Studio Code RPM installer from https://code.visualstudio.com/docs/?dv=linux64_rpm
+
+6. Download and install Atom text editor RPM installer from https://atom.io/download/rpm, or the Visual Studio Code RPM installer from https://code.visualstudio.com/docs/?dv=linux64_rpm
 ```bash
 dnf install <rpm_name>
 ```


### PR DESCRIPTION
Most of the bits required in the Learner Pre-requisites are available in
Fedora so tar file downloads aren't needed for anything except the Atom
editor. Use the node:8 module to get the explicitly 8 LTS release of node.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>