### PR TITLE
split agile overview into separate md files

### DIFF
--- a/slides/estimation.html
+++ b/slides/estimation.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 		<link type="image/x-icon" rel="shortcut icon" href="css/images/favicon.ico" />
-		<title>DO500 - Agile Overview</title>
+		<title>DO500 - Estimation</title>
 
 		<link rel="stylesheet" href="css/reveal.css">
 		<link rel="stylesheet" href="css/theme/redhat.css">
@@ -31,7 +31,7 @@
 					 <h3 class="title-color">Social Contracts</h3>
 				 	 <p class="title-color">DO500</p>
 				</section> -->
-				<section data-markdown="markdown/agile-overview.md"
+				<section data-markdown="markdown/estimation.md"
          data-separator="^\n\n\n"
          data-separator-vertical="^\n\n"
          data-separator-notes="^Note:"

--- a/slides/markdown/agile-overview.md
+++ b/slides/markdown/agile-overview.md
@@ -99,79 +99,6 @@ The agile approach can minimize risk by getting a working piece of software into
 
 
 
-<!-- .slide: id="scrum"-->
-## Common Methodology: SCRUM
-
-
-
-### Origins of Scrum
-![Scrum](images/Agile/scrum.jpg) <!-- {_class="inline-image"} -->
-* Rugby term: used to restart play
-* 1986 Hirotaka Takeuchi and Ikujiro Nonaka published [The New New Product Development Game](https://hbr.org/1986/01/the-new-new-product-development-game)
-* 1990 Jeff Sutherland and Ken Schwaber used scrum for software development
-
-
-
-### 3 Key Roles in Scrum
-* _Product Owner_
-
-   Conveys message of envisioned product and sets priorities for team
-* _Scrum Master_
-
-   Coaches team on Scrum process and helps iterate towards a productive environment
-* _Development Team Members_
-
-   Self-organize to transform backlog items into a potentially releasable product increment
-
-
-
-![Scrum Ceremonies](images/Agile/scrum_process.png)
-
-
-
-| Scrum Event | Purpose |
-| --- | --- |
-| **Sprint Planning** | Commit to a set of defined work  as a team for the upcoming sprint cycle. The end result is the Sprint Backlog. |
-| **Daily Standup** | Daily sync to share common understanding of the goals, coordinate the team effort, report on progress of work, and to communicate problems and improvements. |
-| ** Sprint Review** | Review what was completed during the sprint with all relevant stakeholders to collect feedback. |
-| ** Sprint Retrospective** | Help teams reflect on their internal team process with the goal to continuously improve. |
-| ** Sprint ** | A time boxed event that brings the team towards the goal set for that iteration and ends with reviewing the product increment. |
-
-
-
-### 3 Key Artifacts in Scrum
-* _Product Backlog_
-
-  Set of all baseline requirements prioritized for the team.
-* _Sprint Backlog_
-
-  Subset of the Product Backlog the team agreed to pull into the Sprint to work on.
-* _Product Increment_
-
-  The most important artifact that is produced at the end of each Sprint.
-
-
-
-### Exercise - The Ball Game (Setup)
-
-In Your Teams
-1. Draw a table with two columns and three rows.
-2. Record your estimate for an iteration.
-3. Pass the balls for one minute.
-4. Record the actual score.
-5. Reflect on your team strategy
-
-
-
-### Exercise - The Ball Game (Rules)
-
-1. Pass as many ping pong balls through all the team members.
-2. There must be "air time" between each pass.
-3. You cannot use any artificial containers.
-4. If you drop a ball, you lose a point.
-
-
-
 #### Agile Product Ownership in a Nutshell
 <iframe width="600" height="480" src="https://www.youtube.com/embed/502ILHjX9EE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -180,8 +107,3 @@ In Your Teams
 <!-- .slide: data-background-image="images/chef-background.png", class="white-style" -->
 ### DevOps practices used in this section:
 - [Agile Manifesto](https://agilemanifesto.org)
-- [Sprint Planning](https://openpracticelibrary.com/practice/iteration-planning/)
-- [Daily Standup](https://openpracticelibrary.com/practice/daily-standup/)
-- [Showcase](https://openpracticelibrary.com/practice/showcase/)
-- [Retrospectives](https://openpracticelibrary.com/practice/retrospectives/)
-- [Backlog Refinement](https://openpracticelibrary.com/practice/backlog-refinement)

--- a/slides/markdown/estimation.md
+++ b/slides/markdown/estimation.md
@@ -1,0 +1,16 @@
+<!-- .slide: data-background-image="images/RH_NewBrand_Background.png" -->
+## DevOps Culture and Practice <!-- {_class="course-title"} -->
+### Estimation <!-- {_class="title-color"} -->
+DO500 <!-- {_class="title-color"} -->
+
+
+
+### Exercise - Fruit Salad
+
+1. BLA BLA BLA
+
+
+
+<!-- .slide: data-background-image="images/chef-background.png", class="white-style" -->
+### DevOps practices used in this section:
+- [Relative Estimation](https://openpracticelibrary.com/practice/relative-estimation/)

--- a/slides/markdown/scrum.md
+++ b/slides/markdown/scrum.md
@@ -1,0 +1,82 @@
+<!-- .slide: data-background-image="images/RH_NewBrand_Background.png" -->
+## DevOps Culture and Practice <!-- {_class="course-title"} -->
+### Scrum <!-- {_class="title-color"} -->
+DO500 <!-- {_class="title-color"} -->
+
+
+
+### Origins of Scrum
+![Scrum](images/Agile/scrum.jpg) <!-- {_class="inline-image"} -->
+* Rugby term: used to restart play
+* 1986 Hirotaka Takeuchi and Ikujiro Nonaka published [The New New Product Development Game](https://hbr.org/1986/01/the-new-new-product-development-game)
+* 1990 Jeff Sutherland and Ken Schwaber used scrum for software development
+
+
+
+### 3 Key Roles in Scrum
+* _Product Owner_
+
+   Conveys message of envisioned product and sets priorities for team
+* _Scrum Master_
+
+   Coaches team on Scrum process and helps iterate towards a productive environment
+* _Development Team Members_
+
+   Self-organize to transform backlog items into a potentially releasable product increment
+
+
+
+![Scrum Ceremonies](images/Agile/scrum_process.png)
+
+
+
+| Scrum Event | Purpose |
+| --- | --- |
+| **Sprint Planning** | Commit to a set of defined work  as a team for the upcoming sprint cycle. The end result is the Sprint Backlog. |
+| **Daily Standup** | Daily sync to share common understanding of the goals, coordinate the team effort, report on progress of work, and to communicate problems and improvements. |
+| ** Sprint Review** | Review what was completed during the sprint with all relevant stakeholders to collect feedback. |
+| ** Sprint Retrospective** | Help teams reflect on their internal team process with the goal to continuously improve. |
+| ** Sprint ** | A time boxed event that brings the team towards the goal set for that iteration and ends with reviewing the product increment. |
+
+
+
+### 3 Key Artifacts in Scrum
+* _Product Backlog_
+
+  Set of all baseline requirements prioritized for the team.
+* _Sprint Backlog_
+
+  Subset of the Product Backlog the team agreed to pull into the Sprint to work on.
+* _Product Increment_
+
+  The most important artifact that is produced at the end of each Sprint.
+
+
+
+### Exercise - The Ball Game (Setup)
+
+In Your Teams
+1. Draw a table with two columns and three rows.
+2. Record your estimate for an iteration.
+3. Pass the balls for one minute.
+4. Record the actual score.
+5. Reflect on your team strategy
+
+
+
+### Exercise - The Ball Game (Rules)
+
+1. Pass as many ping pong balls through all the team members.
+2. There must be "air time" between each pass.
+3. You cannot use any artificial containers.
+4. If you drop a ball, you lose a point.
+
+
+
+<!-- .slide: data-background-image="images/chef-background.png", class="white-style" -->
+### DevOps practices used in this section:
+- [Sprint Planning](https://openpracticelibrary.com/practice/iteration-planning/)
+- [Daily Standup](https://openpracticelibrary.com/practice/daily-standup/)
+- [Showcase](https://openpracticelibrary.com/practice/showcase/)
+- [Retrospectives](https://openpracticelibrary.com/practice/retrospectives/)
+- [Backlog Refinement](https://openpracticelibrary.com/practice/backlog-refinement)

--- a/slides/scrum.html
+++ b/slides/scrum.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 		<link type="image/x-icon" rel="shortcut icon" href="css/images/favicon.ico" />
-		<title>DO500 - Agile Overview</title>
+		<title>DO500 - Scrum</title>
 
 		<link rel="stylesheet" href="css/reveal.css">
 		<link rel="stylesheet" href="css/theme/redhat.css">
@@ -31,7 +31,7 @@
 					 <h3 class="title-color">Social Contracts</h3>
 				 	 <p class="title-color">DO500</p>
 				</section> -->
-				<section data-markdown="markdown/agile-overview.md"
+				<section data-markdown="markdown/scrum.md"
          data-separator="^\n\n\n"
          data-separator-vertical="^\n\n"
          data-separator-notes="^Note:"


### PR DESCRIPTION
Created new md files for: 
- Scrum
- Estimation (new content)

Update the md file: Agila Overview.
Still need to create the content for the estimation deck.

Issue: https://github.com/rht-labs/enablement-docs/issues/410