### PR TITLE
FIX add quay.io part 1 jenkins-slave-npm

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -387,7 +387,7 @@ JENKINS_OPTS=--sessionTimeout=720
     post_steps:
       - role: casl-ansible/roles/openshift-imagetag
         vars:
-          source_img: "openshift/jenkins-slave-npm:latest"
+          source_img: "quay.io/openshift/jenkins-slave-npm:latest"
           img_tag: "jenkins-slave-npm:latest"
       - role: casl-ansible/roles/openshift-labels
         vars:

--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -387,7 +387,7 @@ JENKINS_OPTS=--sessionTimeout=720
     post_steps:
       - role: casl-ansible/roles/openshift-imagetag
         vars:
-          source_img: "quay.io/openshift/jenkins-slave-npm:latest"
+          source_img: "quay.io/rht-labs/enablement-npm:latest"
           img_tag: "jenkins-slave-npm:latest"
       - role: casl-ansible/roles/openshift-labels
         vars:


### PR DESCRIPTION
Without quay.io defined you get the following error: 
"Error from server (NotFound): imagestreams.image.openshift.io \"jenkins-slave-npm\"

When running: ansible-playbook apply.yml -e target=tools \
 -i inventory/ \
 -e "filter_tags=jenkins"