### PR TITLE
Updated the README to add ansible_connection

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -269,6 +269,7 @@ MEMORY_LIMIT=1Gi
 <kbd>📝 *enablement-ci-cd/inventory/host_vars/ci-cd-tooling.yml*</kbd>
 ```yaml
 ---
+ansible_connection: local
 openshift_cluster_content:
 - galaxy_requirements:
   - "{{ inventory_dir }}/../exercise-requirements.yml"


### PR DESCRIPTION
Whilst taking part in the D0500 course we noticed the line ansible_connection was missing in the instructions for The Manual Menace task.

The ansible_connection: local was missing from this file. As such when running the job an unreachable error would be generated. 

This line was already in the original file and the instructions just needed a small modification to ensure people left the ansible_connection line present. 

As a result now copying the entire content for ci-cd-tooling.yml works as expected with the change made.