### PR TITLE
🐌fix zap scan reporting 🐌

### DIFF
--- a/exercises/4-an-enslaved-hope/README.md
+++ b/exercises/4-an-enslaved-hope/README.md
@@ -72,7 +72,7 @@ _____
       pre_steps:
         - role: casl-ansible/roles/openshift-imagetag
           vars:
-            source_img: "quay.io/rht-labs/jenkins-slave-zap:do500.v2"
+            source_img: "quay.io/rht-labs/jenkins-slave-zap:do500.v3"
             img_tag: "jenkins-agent-zap:latest"
         - role: casl-ansible/roles/openshift-labels
           vars:

--- a/exercises/5-non-functionals-strike-back/README.md
+++ b/exercises/5-non-functionals-strike-back/README.md
@@ -157,7 +157,7 @@ stage('OWASP Scan') {
               allowMissing: false,
               alwaysLinkToLastBuild: false,
               keepAll: true,
-              reportDir: '',
+              reportDir: '/zap/wrk/',
               reportFiles: 'index.html',
               reportName: 'Zap Branniscan'
             ]


### PR DESCRIPTION
fixes #601 (broken owasp zap scan)

- updates image to latest containers-quickstarts/jenkins-agents/jenkins-agent-zap (dec 2020)
- zap baseline scan still uses python2  which is deprecated (this needs updating in above image)
- report directory updated to reportDir: '/zap/wrk/'

tested working in current DO500 env

![Screenshot from 2021-01-28 19-38-33](https://user-images.githubusercontent.com/712608/106119759-4890a500-61a1-11eb-931b-79d22f7e0a74.png)
