### PR TITLE
Disabling cert validation for TLS connections

### DIFF
--- a/exercises/5-non-functionals-strike-back/README.md
+++ b/exercises/5-non-functionals-strike-back/README.md
@@ -328,8 +328,10 @@ An arbitrary value for the APIs to respond in has been chosen. It is set in the 
 5. Set the `Color ANSI Console Output` on the Build Environment section.
 
 6. Click `Add build step` and select `Execute shell` and add the following to it, replacing `<YOUR_NAME>` as expected. We will just test the `create` and `show` API for the moment. We are grabbing the response code of the perf-test to keep Jenkins running both shells steps and then exiting with whichever fails:
+
 ```bash
-export E2E_TEST_ROUTE=todolist-<YOUR_NAME>-dev.<APPS_URL>
+export NODE_TLS_REJECT_UNAUTHORIZED='0'
+export E2E_TEST_ROUTE=todolist-team5-dev.apps.sogei-1.emea-1.rht-labs.com
 npm install
 set +e
 npm run perf-test:create


### PR DESCRIPTION
This PR fixes the #633 issue.

The `request` module could check the certifications or not for TLS connections. It seems that in this part of the exercise the cert is validated in the TLS connection. Adding the variable `NODE_TLS_REJECT_UNAUTHORIZED`(1), that validation is skipped and then it runs successfully

[1 - NODE_TLS_REJECT_UNAUTHORIZED](https://nodejs.org/api/cli.html#node_tls_reject_unauthorizedvalue)
